### PR TITLE
implemented _check

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,47 +1,29 @@
-exports._check = () => {
-  // DRY up the codebase with this function
-  // First, move the duplicate error checking code here
-  // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()
-};
-
-exports.add = (x, y) => {
+exports._check = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
+};
+
+exports.add = (x, y) => {
+  exports._check(x, y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x / y;
 };
 

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
Removed argument typecheck logic from calculator.js mathematical operations methods (add, subtract, multiply, delete) and stored in _check method. 

_check before:

<img width="552" alt="screen shot 2017-11-13 at 1 49 01 pm" src="https://user-images.githubusercontent.com/16075498/32743073-674aaa82-c879-11e7-8650-ecfd7acacab2.png">

_check after: 

<img width="418" alt="screen shot 2017-11-13 at 1 49 40 pm" src="https://user-images.githubusercontent.com/16075498/32743108-80cda888-c879-11e7-9931-9f61223b4a30.png">

Also changed calculator.test.js to test each calculator method. (changed describe.only() to describe())

<img width="399" alt="screen shot 2017-11-13 at 1 50 35 pm" src="https://user-images.githubusercontent.com/16075498/32743164-a25f4150-c879-11e7-89b2-0cfe691eb18c.png">

