### PR TITLE
DRYed up calculator.js

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,47 +1,29 @@
-exports._check = () => {
-  // DRY up the codebase with this function
-  // First, move the duplicate error checking code here
-  // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()
-};
-
-exports.add = (x, y) => {
+exports._check = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
+};
+
+exports.add = (x, y) => {
+  exports._check(x, y)
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y)
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y)
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y)
   return x / y;
 };
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -8,22 +8,22 @@ exports._check = (x, y) => {
 };
 
 exports.add = (x, y) => {
-  exports._check(x, y)
+  exports._check(x, y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  exports._check(x, y)
+  exports._check(x, y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  exports._check(x, y)
+  exports._check(x, y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  exports._check(x, y)
+  exports._check(x, y);
   return x / y;
 };
 

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
DRYed up calculator.js by moving repeated error checks to a dedicated function. 

Before:
![before](https://user-images.githubusercontent.com/14971644/34266141-2998b856-e646-11e7-8f9d-614920b7bce0.PNG)

After
![after](https://user-images.githubusercontent.com/14971644/34266140-298877ac-e646-11e7-9cc3-6b4a9a03e961.PNG)



