### PR TITLE
Refactored code base with exports._check function and changed descripe.skip to describe

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,47 +1,33 @@
-exports._check = () => {
+exports._check = (x,y) => {
   // DRY up the codebase with this function
   // First, move the duplicate error checking code here
   // Then, invoke this function inside each of the others
   // HINT: you can invoke this function with exports._check()
-};
-
-exports.add = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
+};
+
+exports.add = (x, y) => {
+  exports._check(x,y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x,y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x,y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x,y);
   return x / y;
 };
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,8 +1,4 @@
 exports._check = (x, y) => {
-  // DRY up the codebase with this function
-  // First, move the duplicate error checking code here
-  // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,4 +1,4 @@
-exports._check = (x,y) => {
+exports._check = (x, y) => {
   // DRY up the codebase with this function
   // First, move the duplicate error checking code here
   // Then, invoke this function inside each of the others
@@ -12,22 +12,22 @@ exports._check = (x,y) => {
 };
 
 exports.add = (x, y) => {
-  exports._check(x,y);
+  exports._check(x, y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  exports._check(x,y);
+  exports._check(x, y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  exports._check(x,y);
+  exports._check(x, y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  exports._check(x,y);
+  exports._check(x, y);
   return x / y;
 };
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,8 +1,9 @@
-// DRY up the codebase with this function
-// First, move the duplicate error checking code here
-// Then, invoke this function inside each of the others
-// HINT: you can invoke this function with exports._check()
+
 exports._check = (x, y) => {
+  // DRY up the codebase with this function
+  // First, move the duplicate error checking code here
+  // Then, invoke this function inside each of the others
+  // HINT: you can invoke this function with exports._check()
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,3 +1,7 @@
+// DRY up the codebase with this function
+// First, move the duplicate error checking code here
+// Then, invoke this function inside each of the others
+// HINT: you can invoke this function with exports._check()
 exports._check = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
Refactored code base with exports._check function and changed descripe.skip to describe.
BEFORE:
calculator.js
```
exports._check = (x, y) => {
  // DRY up the codebase with this function
  // First, move the duplicate error checking code here
  // Then, invoke this function inside each of the others
  // HINT: you can invoke this function with exports._check()
};

exports.add = (x, y) => {
  if (typeof x !== 'number') {
    throw new TypeError(`${x} is not a number`);
  }
  if (typeof y !== 'number') {
    throw new TypeError(`${y} is not a number`);
  }
  return x + y;
};

```
calculator.test.js
```
describe.skip('_check', () => {
  beforeEach(() => {
    sinon.spy(calculator, '_check');
  });
```
AFTER:
calculator.js
```
exports._check = (x, y) => {
  // DRY up the codebase with this function
  // First, move the duplicate error checking code here
  // Then, invoke this function inside each of the others
  // HINT: you can invoke this function with exports._check()
  if (typeof x !== 'number') {
    throw new TypeError(`${x} is not a number`);
  }
  if (typeof y !== 'number') {
    throw new TypeError(`${y} is not a number`);
  }
};

exports.add = (x, y) => {
  exports._check(x, y);
  return x + y;
};
```
calculator.test.js
```
describe('_check', () => {
  beforeEach(() => {
    sinon.spy(calculator, '_check');
  });
```