### PR TITLE
Implemented _check and removed superfluous error checking

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,47 +1,33 @@
-exports._check = () => {
-  // DRY up the codebase with this function
-  // First, move the duplicate error checking code here
-  // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()
-};
-
-exports.add = (x, y) => {
+exports._check = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
+};
+
+exports.add = (x, y) => {
+  exports._check(x, y);
+  
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
+  
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
+  
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
+  
   return x / y;
 };
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -9,25 +9,25 @@ exports._check = (x, y) => {
 
 exports.add = (x, y) => {
   exports._check(x, y);
-  
+
   return x + y;
 };
 
 exports.subtract = (x, y) => {
   exports._check(x, y);
-  
+
   return x - y;
 };
 
 exports.multiply = (x, y) => {
   exports._check(x, y);
-  
+
   return x * y;
 };
 
 exports.divide = (x, y) => {
   exports._check(x, y);
-  
+
   return x / y;
 };
 

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
- Implemented `calculator._check` with type checking for `x` and `y` to ensure they are both of type number.
Removed the superfluous error checking in each of the calculator functions and replaced it with calls to `exports._check`.
Updated the first `describe` in `calculator.test.js` to run instead of being skipped.