### PR TITLE
Implement _check

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,47 +1,29 @@
-exports._check = () => {
-  // DRY up the codebase with this function
-  // First, move the duplicate error checking code here
-  // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()
-};
-
-exports.add = (x, y) => {
+exports._check = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
+};
+
+exports.add = (x, y) => {
+  exports._check(x, y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x / y;
 };
 

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
As per the "DRY up the codebase #1" issue, I Implemented a type-checking function -- i.e., _check() -- to confirm that both inputs to the add(), subtract(), multiply(), and divide() functions are numbers. 

<img width="378" alt="screen shot 2018-12-06 at 3 02 24 pm" src="https://user-images.githubusercontent.com/39537212/49611711-00cab600-f968-11e8-9947-68c010f096d7.png">

This eliminated the unnecessary duplicate type-checking done in each of the aforementioned functions.

Before:
<img width="369" alt="screen shot 2018-12-06 at 3 04 40 pm" src="https://user-images.githubusercontent.com/39537212/49611822-674fd400-f968-11e8-9a13-0bbf7141535c.png">


After:
<img width="217" alt="screen shot 2018-12-06 at 3 06 05 pm" src="https://user-images.githubusercontent.com/39537212/49611849-7d5d9480-f968-11e8-8370-fdb17cd751ea.png">

