### PR TITLE
Implement _check

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,4 +1,4 @@
-exports._check = () => {
+exports._check = (x,y) => {
   // DRY up the codebase with this function
   // First, move the duplicate error checking code here
   // Then, invoke this function inside each of the others
@@ -6,6 +6,7 @@ exports._check = () => {
 };
 
 exports.add = (x, y) => {
+  exports._check(x,y);
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
@@ -16,6 +17,7 @@ exports.add = (x, y) => {
 };
 
 exports.subtract = (x, y) => {
+  exports._check(x,y);
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
@@ -26,6 +28,7 @@ exports.subtract = (x, y) => {
 };
 
 exports.multiply = (x, y) => {
+  exports._check(x,y);
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
@@ -36,6 +39,7 @@ exports.multiply = (x, y) => {
 };
 
 exports.divide = (x, y) => {
+  exports._check(x,y);
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,51 +1,34 @@
 exports._check = (x,y) => {
-  // DRY up the codebase with this function
-  // First, move the duplicate error checking code here
-  // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()
-};
-
-exports.add = (x, y) => {
-  exports._check(x,y);
-  if (typeof x !== 'number') {
+  if (typeof x !== 'number'){
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
+
+}
+
+exports.add = (x, y) => {
+  exports._check(x,y);
+  
   return x + y;
 };
 
 exports.subtract = (x, y) => {
   exports._check(x,y);
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+
   return x - y;
 };
 
 exports.multiply = (x, y) => {
   exports._check(x,y);
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  
   return x * y;
 };
 
 exports.divide = (x, y) => {
   exports._check(x,y);
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+
   return x / y;
 };
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,33 +1,33 @@
-exports._check = (x,y) => {
-  if (typeof x !== 'number'){
+exports._check = (x, y) => {
+  if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
-
-}
+  return x + y;
+};
 
 exports.add = (x, y) => {
-  exports._check(x,y);
-  
+  exports._check(x, y);
+
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  exports._check(x,y);
+  exports._check(x, y);
 
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  exports._check(x,y);
-  
+  exports._check(x, y);
+
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  exports._check(x,y);
+  exports._check(x, y);
 
   return x / y;
 };

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
This Pull Request was made to modify the code base and make it cleaner.

Issue: There was a duplication of code in the src/calculator.js file. The variable type was to be checked before the functions(exports.add(x,y), exports.subtract(x,y), exports.multiply(x,y), exports.divide(x,y)) were run. However each of the functions performed this variable check which was unnecessarily repititive, redundant and made for messy code.

Proposed solution: To move the variable-check code to exports._check() function and pass in exports._check() into each of the above functions to do the error checking for us, thus making the code base cleaner.
