### PR TITLE
Fixed coding style violations according to Lint

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -12,22 +12,22 @@ exports._check = (x, y) => {
 };
 
 exports.add = (x, y) => {
-  exports._check(x,y); 
+  exports._check(x, y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  exports._check(x,y); 
+  exports._check(x, y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  exports._check(x,y); 
+  exports._check(x, y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  exports._check(x,y); 
+  exports._check(x, y);
   return x / y;
 };
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,47 +1,33 @@
-exports._check = () => {
+exports._check = (x, y) => {
   // DRY up the codebase with this function
   // First, move the duplicate error checking code here
   // Then, invoke this function inside each of the others
   // HINT: you can invoke this function with exports._check()
-};
-
-exports.add = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
+};
+
+exports.add = (x, y) => {
+  exports._check(x,y); 
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x,y); 
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x,y); 
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x,y); 
   return x / y;
 };
 

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe.only('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
Fixed coding style violations: trailing white-space and spaces needed in between parameters. 
