### PR TITLE
Implement _check and fix style guide violations.

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,47 +1,29 @@
-exports._check = () => {
-  // DRY up the codebase with this function
-  // First, move the duplicate error checking code here
-  // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()
-};
-
-exports.add = (x, y) => {
+exports._check = (x,y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
+};
+
+exports.add = (x, y) => {
+  exports._check(x,y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x,y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x,y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x,y);
   return x / y;
 };
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,28 +1,31 @@
-export function _check(x, y) {
+exports._check = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
+
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
-}
+};
 
-export function add(x, y) {
-  _check(x, y);
+exports.add = (x, y) => {
+  exports._check(x, y);
   return x + y;
-}
+};
 
-export function subtract(x, y) {
-  _check(x, y);
+exports.subtract = (x, y) => {
+  exports._check(x, y);
   return x - y;
-}
+};
 
-export function multiply(x, y) {
-  _check(x, y);
+exports.multiply = (x, y) => {
+  exports._check(x, y);
   return x * y;
-}
+};
 
-export function divide(x, y) {
-  _check(x, y);
+exports.divide = (x, y) => {
+  exports._check(x, y);
   return x / y;
-}
+};
+
+module.exports = exports;

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,30 +1,28 @@
-exports._check = (x,y) => {
+export function _check(x, y) {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
-};
+}
 
-exports.add = (x, y) => {
-  exports._check(x,y);
+export function add(x, y) {
+  _check(x, y);
   return x + y;
-};
+}
 
-exports.subtract = (x, y) => {
-  exports._check(x,y);
+export function subtract(x, y) {
+  _check(x, y);
   return x - y;
-};
+}
 
-exports.multiply = (x, y) => {
-  exports._check(x,y);
+export function multiply(x, y) {
+  _check(x, y);
   return x * y;
-};
+}
 
-exports.divide = (x, y) => {
-  exports._check(x,y);
+export function divide(x, y) {
+  _check(x, y);
   return x / y;
-};
-
-module.exports = exports;
+}

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
The below commit address issue #1 - **DRY up the codebase.**

This change removes the duplicate validation checks by putting them in a centralised function *_check* which is used by each action of the calculator; namely, *add*, *subtract*, *multiply* and *divide*. 

Prior to this change each action of the calculator was required to handle its own validation checks:

```
exports.divide = (x, y) => {
  if (typeof x !== 'number') {
    throw new TypeError(`${x} is not a number`);
  }
  if (typeof y !== 'number') {
    throw new TypeError(`${y} is not a number`);
  }
  return x / y;
};
```

The centralised *_check* function now handles this logic and is called in each respective calculator action method.

```
exports.divide = (x, y) => {
  exports._check(x,y);
  return x / y;
};
```

This logic is now centralised and should this validation need to be updated, this will only need to be done in one place.

```
exports._check = (x,y) => {
  if (typeof x !== 'number') {
    throw new TypeError(`${x} is not a number`);
  }
  if (typeof y !== 'number') {
    throw new TypeError(`${y} is not a number`);
  }
};
```
