### PR TITLE
Implement _check

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,48 +1,36 @@
-exports._check = () => {
+exports._check = (x, y) => {
   // DRY up the codebase with this function
   // First, move the duplicate error checking code here
   // Then, invoke this function inside each of the others
   // HINT: you can invoke this function with exports._check()
+  
+  if (typeof x !== 'number') {
+      throw new TypeError(`${x} is not a number`);
+  }
+  
+  if (typeof y !== 'number') {
+       throw new TypeError(`${y} is not a number`);
+  }
 };
 
 exports.add = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
-  return x + y;
-};
+    exports._check(x, y);
+    return x + y;
+    };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
-  return x - y;
+    exports._check(x, y);
+    return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
-  return x * y;
+    exports._check(x, y);
+    return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
-  return x / y;
+    exports._check(x, y);
+    return x / y;
 };
 
 module.exports = exports;

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
Within calculator.js, there was a bunch of redundant code which checked whether x and y are numbers multiple times. Since every function in calculator.js checks whether both x and y are "number" type objects, I wrote the error checking code within _check and put calls to _check within the other functions. This makes the code significantly less redundant.