### PR TITLE
Implement _check and used the automated styling script

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -3,34 +3,34 @@ exports._check = (x, y) => {
   // First, move the duplicate error checking code here
   // Then, invoke this function inside each of the others
   // HINT: you can invoke this function with exports._check()
-  
+
   if (typeof x !== 'number') {
-      throw new TypeError(`${x} is not a number`);
+    throw new TypeError(`${x} is not a number`);
   }
-  
+
   if (typeof y !== 'number') {
-       throw new TypeError(`${y} is not a number`);
+    throw new TypeError(`${y} is not a number`);
   }
 };
 
 exports.add = (x, y) => {
-    exports._check(x, y);
-    return x + y;
-    };
+  exports._check(x, y);
+  return x + y;
+};
 
 exports.subtract = (x, y) => {
-    exports._check(x, y);
-    return x - y;
+  exports._check(x, y);
+  return x - y;
 };
 
 exports.multiply = (x, y) => {
-    exports._check(x, y);
-    return x * y;
+  exports._check(x, y);
+  return x * y;
 };
 
 exports.divide = (x, y) => {
-    exports._check(x, y);
-    return x / y;
+  exports._check(x, y);
+  return x / y;
 };
 
 module.exports = exports;

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,48 +1,36 @@
-exports._check = () => {
+exports._check = (x, y) => {
   // DRY up the codebase with this function
   // First, move the duplicate error checking code here
   // Then, invoke this function inside each of the others
   // HINT: you can invoke this function with exports._check()
+  
+  if (typeof x !== 'number') {
+      throw new TypeError(`${x} is not a number`);
+  }
+  
+  if (typeof y !== 'number') {
+       throw new TypeError(`${y} is not a number`);
+  }
 };
 
 exports.add = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
-  return x + y;
-};
+    exports._check(x, y);
+    return x + y;
+    };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
-  return x - y;
+    exports._check(x, y);
+    return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
-  return x * y;
+    exports._check(x, y);
+    return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
-  return x / y;
+    exports._check(x, y);
+    return x / y;
 };
 
 module.exports = exports;

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
_check is defined to be a function that checks whether two variables, x and y, are both number types. _check is called throughout the four functions: add, subtract, multiply, and divide. This reduces the redundancy in our code base.

I accidentally left some extra spacing in the last pull request so I used the automated script provided to remove the extra spacing and fix some other minor styling errors.