### PR TITLE
Implement _check

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -4,10 +4,10 @@ exports._check = (x, y) => {
 
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
-  }
+   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
-  }
+   }
 
 
   // Then, invoke this function inside each of the others

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -4,10 +4,10 @@ exports._check = (x, y) => {
 
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
-}
+ }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
-}
+ }
 
 
   // Then, invoke this function inside each of the others

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -4,10 +4,10 @@ exports._check = (x, y) => {
 
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
-  }
+}
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
-  }
+}
 
 
   // Then, invoke this function inside each of the others
@@ -17,21 +17,21 @@ exports._check = (x, y) => {
 exports.add = (x, y) => {
    exports._check(x, y);
    return x + y;
-};
+}
 
 exports.subtract = (x, y) => {
    exports._check(x, y);
    return x - y;
-};
+}
 
 exports.multiply = (x, y) => {
    exports._check(x, y);
    return x * y;
-};
+}
 
 exports.divide = (x, y) => {
    exports._check(x, y);
    return x / y;
-};
+}
 
 module.exports = exports;

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,47 +1,38 @@
-exports._check = () => {
+exports._check = (x,y) => {
   // DRY up the codebase with this function
+
   // First, move the duplicate error checking code here
+
+  if (typeof x !== 'number') {
+    throw new TypeError(`${x} is not a number`);
+  }
+  
+  if (typeof y !== 'number') {
+    throw new TypeError(`${y} is not a number`);
+  };  
+
+
   // Then, invoke this function inside each of the others
   // HINT: you can invoke this function with exports._check()
 };
 
 exports.add = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
-  return x + y;
+   exports._check(x,y)
+   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x,y)
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x,y)
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x,y)
   return x / y;
 };
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -6,10 +6,10 @@ exports._check = (x,y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
-  
+
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
-  };  
+  }
 
 
   // Then, invoke this function inside each of the others
@@ -17,22 +17,22 @@ exports._check = (x,y) => {
 };
 
 exports.add = (x, y) => {
-   exports._check(x,y)
-   return x + y;
+  exports._check(x, y);
+  return x + y;
 };
 
 exports.subtract = (x, y) => {
-  exports._check(x,y)
+  exports._check(x, y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  exports._check(x,y)
+  exports._check(x, y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  exports._check(x,y)
+  exports._check(x, y);
   return x / y;
 };
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -3,9 +3,11 @@ exports._check = (x, y) => {
   // First, move the duplicate error checking code here
 
    if (typeof x !== 'number') {
+     
      throw new TypeError(`${x} is not a number`);
    }
    if (typeof y !== 'number') {
+     
      throw new TypeError(`${y} is not a number`);
    }
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -2,12 +2,12 @@ exports._check = (x, y) => {
   // DRY up the codebase with this function
   // First, move the duplicate error checking code here
 
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-     }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-    }
+   if (typeof x !== 'number') {
+     throw new TypeError(`${x} is not a number`);
+   }
+   if (typeof y !== 'number') {
+     throw new TypeError(`${y} is not a number`);
+   }
 
 
   // Then, invoke this function inside each of the others

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -4,10 +4,10 @@ exports._check = (x, y) => {
 
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
-   }
+     }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
-   }
+    }
 
 
   // Then, invoke this function inside each of the others

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -2,14 +2,12 @@ exports._check = (x, y) => {
   // DRY up the codebase with this function
   // First, move the duplicate error checking code here
 
-   if (typeof x !== 'number') {
-     
-     throw new TypeError(`${x} is not a number`);
-   }
-   if (typeof y !== 'number') {
-     
-     throw new TypeError(`${y} is not a number`);
-   }
+  if (typeof x !== 'number') {
+    throw new TypeError(`${x} is not a number`);
+  }
+  if (typeof y !== 'number') {
+    throw new TypeError(`${y} is not a number`);
+  }
 
 
   // Then, invoke this function inside each of the others
@@ -17,23 +15,23 @@ exports._check = (x, y) => {
 };
 
 exports.add = (x, y) => {
-   exports._check(x, y);
-   return x + y;
-}
+  exports._check(x, y);
+  return x + y;
+};
 
 exports.subtract = (x, y) => {
-   exports._check(x, y);
-   return x - y;
-}
+  exports._check(x, y);
+  return x - y;
+};
 
 exports.multiply = (x, y) => {
-   exports._check(x, y);
-   return x * y;
-}
+  exports._check(x, y);
+  return x * y;
+};
 
 exports.divide = (x, y) => {
-   exports._check(x, y);
-   return x / y;
-}
+  exports._check(x, y);
+  return x / y;
+};
 
 module.exports = exports;

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -4,10 +4,10 @@ exports._check = (x, y) => {
 
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
- }
+  }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
- }
+  }
 
 
   // Then, invoke this function inside each of the others

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,12 +1,10 @@
-exports._check = (x,y) => {
+exports._check = (x, y) => {
   // DRY up the codebase with this function
-
   // First, move the duplicate error checking code here
 
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
-
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
@@ -17,23 +15,23 @@ exports._check = (x,y) => {
 };
 
 exports.add = (x, y) => {
-  exports._check(x, y);
-  return x + y;
+   exports._check(x, y);
+   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  exports._check(x, y);
-  return x - y;
+   exports._check(x, y);
+   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  exports._check(x, y);
-  return x * y;
+   exports._check(x, y);
+   return x * y;
 };
 
 exports.divide = (x, y) => {
-  exports._check(x, y);
-  return x / y;
+   exports._check(x, y);
+   return x / y;
 };
 
 module.exports = exports;

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
Here is my first contribution

I changed  in  /src/calculator.js 

exports._check = (x,y) => {
  // DRY up the codebase with this function

  // First, move the duplicate error checking code here

  if (typeof x !== 'number') {
    throw new TypeError(`${x} is not a number`);
  }

  if (typeof y !== 'number') {
    throw new TypeError(`${y} is not a number`);
  };


  // Then, invoke this function inside each of the others
  // HINT: you can invoke this function with exports._check()
};

exports.add = (x, y) => {
   exports._check(x,y)
   return x + y;
};

exports.subtract = (x, y) => {
  exports._check(x,y)
  return x - y;
};

exports.multiply = (x, y) => {
  exports._check(x,y)
  return x * y;
};

exports.divide = (x, y) => {
  exports._check(x,y)
  return x / y;
};

module.exports = exports;


--> and also changed in   /src/calculator.test.js


-1  
  describe.skip('_check', () => {
  beforeEach(() => {
    sinon.spy(calculator, '_check');
  });
+1
describe('_check', () => {
  beforeEach(() => {
    sinon.spy(calculator, '_check');
  });
