### PR TITLE
Implement _check

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,47 +1,29 @@
-exports._check = () => {
-  // DRY up the codebase with this function
-  // First, move the duplicate error checking code here
-  // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()
-};
-
-exports.add = (x, y) => {
+exports._check = (x,y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
+};
+
+exports.add = (x,y) => {
+  exports._check(x, y);
   return x + y;
 };
 
-exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+exports.subtract = (x,y) => {
+  exports._check(x, y);
   return x - y;
 };
 
-exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+exports.multiply = (x,y) => {
+  exports._check(x, y);
   return x * y;
 };
 
-exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+exports.divide = (x,y) => {
+  exports._check(x, y);
   return x / y;
 };
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,4 +1,4 @@
-exports._check = (x,y) => {
+exports._check = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
@@ -7,22 +7,22 @@ exports._check = (x,y) => {
   }
 };
 
-exports.add = (x,y) => {
+exports.add = (x, y) => {
   exports._check(x, y);
   return x + y;
 };
 
-exports.subtract = (x,y) => {
+exports.subtract = (x, y) => {
   exports._check(x, y);
   return x - y;
 };
 
-exports.multiply = (x,y) => {
+exports.multiply = (x, y) => {
   exports._check(x, y);
   return x * y;
 };
 
-exports.divide = (x,y) => {
+exports.divide = (x, y) => {
   exports._check(x, y);
   return x / y;
 };

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
Removed code duplication within simple math methods. Duplicated code was just corner-case checking. Reduced it down to one method that is still called in the beginning of each function.