### PR TITLE
_check function implementation and unnecessary code removal

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,47 +1,33 @@
-exports._check = () => {
+exports._check = (x,y) => {
   // DRY up the codebase with this function
   // First, move the duplicate error checking code here
-  // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()
-};
-
-exports.add = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
+  // Then, invoke this function inside each of the others
+  // HINT: you can invoke this function with exports._check()	
+};
+
+exports.add = (x, y) => {
+	exports._check(x,y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x,y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x,y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x,y);
   return x / y;
 };
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,4 +1,4 @@
-exports._check = (x,y) => {
+exports._check = (x, y) => {
   // DRY up the codebase with this function
   // First, move the duplicate error checking code here
   if (typeof x !== 'number') {
@@ -8,26 +8,26 @@ exports._check = (x,y) => {
     throw new TypeError(`${y} is not a number`);
   }
   // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()	
+  // HINT: you can invoke this function with exports._check()
 };
 
 exports.add = (x, y) => {
-	exports._check(x,y);
+  exports._check(x, y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  exports._check(x,y);
+  exports._check(x, y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  exports._check(x,y);
+  exports._check(x, y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  exports._check(x,y);
+  exports._check(x, y);
   return x / y;
 };
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,14 +1,10 @@
 exports._check = (x, y) => {
-  // DRY up the codebase with this function
-  // First, move the duplicate error checking code here
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
-  // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()
 };
 
 exports.add = (x, y) => {

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
<!--
Yay, you found the Pull Request button!

Before submitting your changes for review, consider the message you write here carefully. The goal is to make it as easy as possible for a reviewer to understand, and accept, your changes. Here are some tips for a great message:

* Include context about your changes, linking to relative issues/documentation
* Write clearly and concisely
* Provide screenshots of before/after
* Review the contributing guidelines for any other specifics
-->


Greetings,

The current pull request fixes the following issues:

- **Added implementation for the _check function of calculator.js**

Before

```js
exports._check = () => {
  // DRY up the codebase with this function
  // First, move the duplicate error checking code here
  // Then, invoke this function inside each of the others
  // HINT: you can invoke this function with exports._check()
};
```

After

```js
exports._check = (x, y) => {
  if (typeof x !== 'number') {
    throw new TypeError(`${x} is not a number`);
  }
  if (typeof y !== 'number') {
    throw new TypeError(`${y} is not a number`);
  }
};
```



 - **Replaced the duplicate error checking code with _check(x, y)**



Thank you in advance,

