### PR TITLE
Dry up the codebase

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,4 +1,10 @@
-exports._check = () => {
+exports._check = (x, y) => {
+  if (typeof x !== 'number') {
+    throw new TypeError(`${x} is not a number`);
+  }
+  if (typeof y !== 'number') {
+    throw new TypeError(`${y} is not a number`);
+  }
   // DRY up the codebase with this function
   // First, move the duplicate error checking code here
   // Then, invoke this function inside each of the others
@@ -6,42 +12,25 @@ exports._check = () => {
 };
 
 exports.add = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y)
+  
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y)
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y)
+  
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y)
+  
   return x / y;
 };
 

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });
@@ -45,15 +45,6 @@ describe.skip('_check', () => {
 });
 
 describe('add', () => {
-  it('should throw a TypeError if arguments are not numbers', () => {
-    expect(() => calculator.add(40, '2')).to.throw(TypeError);
-    expect(() => calculator.add(40, [])).to.throw(TypeError);
-    expect(() => calculator.add(40, {})).to.throw(TypeError);
-    expect(() => calculator.add('40', 2)).to.throw(TypeError);
-    expect(() => calculator.add([], 2)).to.throw(TypeError);
-    expect(() => calculator.add({}, 2)).to.throw(TypeError);
-  });
-
   it('should add two positive numbers', () => {
     expect(calculator.add(40, 2)).to.equal(42);
   });
@@ -68,15 +59,6 @@ describe('add', () => {
 });
 
 describe('subtract', () => {
-  it('should throw a TypeError if arguments are not numbers', () => {
-    expect(() => calculator.subtract(40, '2')).to.throw(TypeError);
-    expect(() => calculator.subtract(40, [])).to.throw(TypeError);
-    expect(() => calculator.subtract(40, {})).to.throw(TypeError);
-    expect(() => calculator.subtract('40', 2)).to.throw(TypeError);
-    expect(() => calculator.subtract([], 2)).to.throw(TypeError);
-    expect(() => calculator.subtract({}, 2)).to.throw(TypeError);
-  });
-
   it('should subtract two positive numbers', () => {
     expect(calculator.subtract(44, 2)).to.equal(42);
   });
@@ -91,15 +73,6 @@ describe('subtract', () => {
 });
 
 describe('multiply', () => {
-  it('should throw a TypeError if arguments are not numbers', () => {
-    expect(() => calculator.multiply(40, '2')).to.throw(TypeError);
-    expect(() => calculator.multiply(40, [])).to.throw(TypeError);
-    expect(() => calculator.multiply(40, {})).to.throw(TypeError);
-    expect(() => calculator.multiply('40', 2)).to.throw(TypeError);
-    expect(() => calculator.multiply([], 2)).to.throw(TypeError);
-    expect(() => calculator.multiply({}, 2)).to.throw(TypeError);
-  });
-
   it('should multiply two positive numbers', () => {
     expect(calculator.multiply(6, 7)).to.equal(42);
   });
@@ -114,15 +87,6 @@ describe('multiply', () => {
 });
 
 describe('divide', () => {
-  it('should throw a TypeError if arguments are not numbers', () => {
-    expect(() => calculator.divide(40, '2')).to.throw(TypeError);
-    expect(() => calculator.divide(40, [])).to.throw(TypeError);
-    expect(() => calculator.divide(40, {})).to.throw(TypeError);
-    expect(() => calculator.divide('40', 2)).to.throw(TypeError);
-    expect(() => calculator.divide([], 2)).to.throw(TypeError);
-    expect(() => calculator.divide({}, 2)).to.throw(TypeError);
-  });
-
   it('should divide two positive numbers', () => {
     expect(calculator.divide(84, 2)).to.equal(42);
   });


### PR DESCRIPTION
Implemented the _check function in calculator.js to remove repeated code that checks the argument's types, _check runs in all of the calculator functions. Also removed tests that tested using incorrect types in calculator functions, one test is used to test the _check function instead.