### PR TITLE
chore: implement _check

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,47 +1,25 @@
-exports._check = () => {
-  // DRY up the codebase with this function
-  // First, move the duplicate error checking code here
-  // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()
+exports._check = (num1, num2) => {
+  if (typeof num1 !== 'number') throw new TypeError(`${num1} is not a number`);
+  if (typeof num2 !== 'number') throw new TypeError(`${num2} is not a number`);
 };
 
 exports.add = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x / y;
 };
 

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
DRY-ed up the codebase to ensure `exports._check` is called only once for each operation. 
The check function is now called from within each operation to perform the type check and throw errors if required.

Before:
![image](https://user-images.githubusercontent.com/15942221/185051593-9bca6c15-fb22-4531-ab8f-60cafcc1e048.png)

After:
![image](https://user-images.githubusercontent.com/15942221/185051729-9623466a-58e5-4fb1-819d-cccb3f4b8025.png)


