### PR TITLE
Fixed duplication check code block

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -5,44 +5,34 @@ exports._check = () => {
   // HINT: you can invoke this function with exports._check()
 };
 
-exports.add = (x, y) => {
+// This function checks if the given arguments are of type `number`
+// and throws a TypeError if not.
+const _check = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
+};
+
+exports.add = (x, y) => {
+  _check(x, y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  _check(x, y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  _check(x, y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  _check(x, y);
   return x / y;
 };
 
-module.exports = exports;


### PR DESCRIPTION
I removed the exports._check function and made _check a private function (i.e., not exported). The comment now explains that _check checks if the arguments are of type number and throws a TypeError if not. Each of the four arithmetic functions now calls _check with its arguments to avoid repeating the same type checking code in multiple places, thus making the code more DRY.