### PR TITLE
Implemented _check, fixing #1

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,47 +1,33 @@
-exports._check = () => {
+exports._check = (x, y) => {
   // DRY up the codebase with this function
   // First, move the duplicate error checking code here
   // Then, invoke this function inside each of the others
   // HINT: you can invoke this function with exports._check()
+  if (typeof x !== 'number') {
+      throw new TypeError(`${x} is not a number`);
+  }
+  if (typeof y !== 'number') {
+      throw new TypeError(`${y} is not a number`);
+  }
 };
 
 exports.add = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+    exports._check(x, y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+    exports._check(x, y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+    exports._check(x, y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+    exports._check(x, y);
   return x / y;
 };
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,33 +1,29 @@
 exports._check = (x, y) => {
-  // DRY up the codebase with this function
-  // First, move the duplicate error checking code here
-  // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()
   if (typeof x !== 'number') {
-      throw new TypeError(`${x} is not a number`);
+    throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
-      throw new TypeError(`${y} is not a number`);
+    throw new TypeError(`${y} is not a number`);
   }
 };
 
 exports.add = (x, y) => {
-    exports._check(x, y);
+  exports._check(x, y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-    exports._check(x, y);
+  exports._check(x, y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-    exports._check(x, y);
+  exports._check(x, y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-    exports._check(x, y);
+  exports._check(x, y);
   return x / y;
 };
 

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
Fixed issue #1 by following the instructions.
The function _check looks like this:
``exports._check = (x, y) => {``
``  if (typeof x !== 'number') {``
``    throw new TypeError(`${x} is not a number`);``
``  }``
``  if (typeof y !== 'number') {``
``    throw new TypeError(`${y} is not a number`);``
``  }``
``};``
An example screenshot of how the function is used:
![Screenshot - 11 07 2023 , 23_24_32](https://github.com/danthareja/contribute-to-open-source/assets/4905061/fb8b8249-6230-4cf6-83a7-efb9ffe73bc5)
