### PR TITLE
Implement _check

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -12,24 +12,24 @@ exports._check = (x, y) => {
 };
 
 exports.add = (x, y) => {
-exports._check(x,y);
+  exports._check(x, y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-exports._check(x,y);
+  exports._check(x, y);
 
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-exports._check(x,y);
+  exports._check(x, y);
 
   return x * y;
 };
 
 exports.divide = (x, y) => {
-exports._check(x,y);
+  exports._check(x, y);
 
   return x / y;
 };

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,47 +1,36 @@
-exports._check = () => {
+exports._check = (x, y) => {
   // DRY up the codebase with this function
   // First, move the duplicate error checking code here
   // Then, invoke this function inside each of the others
   // HINT: you can invoke this function with exports._check()
-};
-
-exports.add = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
+};
+
+exports.add = (x, y) => {
+exports._check(x,y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+exports._check(x,y);
+
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+exports._check(x,y);
+
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+exports._check(x,y);
+
   return x / y;
 };
 

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
Fixed _check as all tests were failing
  - TypeError not thrown if inputs were not numbers
  - Check was not called in add, subtract, multiply, or divide, which means those functions were not throwing type errors
  
Changes:
-Implemented _check to throw a TypeError if any of the inputs were not numbers
-Used _check in add,subtract,multiply, so that they may throw type errors if necessary.
-All test suites passed

