### PR TITLE
Fix:"Implement _check" #1

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,11 +1,4 @@
-exports._check = () => {
-  // DRY up the codebase with this function
-  // First, move the duplicate error checking code here
-  // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()
-};
-
-exports.add = (x, y) => {
+exports._check = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
@@ -15,33 +8,23 @@ exports.add = (x, y) => {
   return x + y;
 };
 
+exports.add = (x, y) => {
+  exports._check(x, y);
+  return x + y;
+};
+
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x / y;
 };
 

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
This PR addresses Issue https://github.com/danthareja/contribute-to-open-source/issues/1.

src/calculator.js contained duplicate code that checked variable types before performing arithmetic on the variables.

The proposed solution: move the duplicate code to the function exports._check() and do the error-checking by calling this function from within exports.add(), exports.subtract(), exports.multiply(), and exports.divide().