### PR TITLE
Implement _check

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,47 +1,29 @@
-exports._check = () => {
-  // DRY up the codebase with this function
-  // First, move the duplicate error checking code here
-  // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()
-};
-
-exports.add = (x, y) => {
+exports._check = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
+};
+
+exports.add = (x, y) => {
+  exports._check(x, y);
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check(x, y);
   return x / y;
 };
 

--- a/src/calculator.test.js
+++ b/src/calculator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 const calculator = require('./calculator');
 
-describe.skip('_check', () => {
+describe('_check', () => {
   beforeEach(() => {
     sinon.spy(calculator, '_check');
   });


### PR DESCRIPTION
The _check was added, removing unnecessary code from the `add`, `subtract`, `multiply `and `divide` functions.
```js
exports._check = (x, y) => {
  if (typeof x !== 'number') {
    throw new TypeError(`${x} is not a number`);
  }
  if (typeof y !== 'number') {
    throw new TypeError(`${y} is not a number`);
  }
};
```
All tests passed and the test skips were removed
```js
describe('_check', () => {
  // ...
}
```